### PR TITLE
Sort by Rank

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cardpack"
 description = "Generic Deck of Cards"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["folkengine <gaoler@electronicpanopticon.com>"]
 repository = "https://github.com/ContractBridge/cardpack.rs.git"
 homepage = "https://github.com/ContractBridge/cardpack.rs"

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -43,6 +43,16 @@ impl Card {
         Card::new(Rank::new(rank), Suit::new(suit))
     }
 
+    #[must_use]
+    pub fn to_rank_weight(&self) -> Card {
+        Card {
+            weight: self.rank.weight,
+            index: self.index.clone(),
+            suit: self.suit,
+            rank: self.rank,
+        }
+    }
+
     /// Returns a Symbol String for the Card.
     #[must_use]
     pub fn symbol(&self, lid: &LanguageIdentifier) -> String {
@@ -164,6 +174,11 @@ mod card_tests {
         };
 
         assert_eq!(expected, Card::new(Rank::new(ACE), Suit::new(SPADES)));
+    }
+
+    #[test]
+    fn to_rank_weight() {
+
     }
 
     #[test]

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -43,10 +43,12 @@ impl Card {
         Card::new(Rank::new(rank), Suit::new(suit))
     }
 
+    /// Returns a Card where the sorting emphasizes its `Rank` weight over its `Suit` weight.
+    /// So `K♥ A♥ A♠ K♠` would return `A♠ A♥ K♠ K♥` instead of `A♠ K♠ A♥ K♥`.
     #[must_use]
     pub fn to_rank_weight(&self) -> Card {
         Card {
-            weight: self.rank.weight,
+            weight: Card::determine_rank_weight(&self.suit, &self.rank),
             index: self.index.clone(),
             suit: self.suit,
             rank: self.rank,
@@ -99,6 +101,11 @@ impl Card {
         let rank = rank.index_default();
         let suit = suit.index_default();
         format!("{}{}", rank, suit)
+    }
+
+    /// Prioritizes sorting by Suit and then by Rank.
+    fn determine_rank_weight(suit: &Suit, rank: &Rank) -> u32 {
+        (rank.weight * 1000) + suit.weight
     }
 
     /// Prioritizes sorting by Suit and then by Rank.
@@ -177,9 +184,7 @@ mod card_tests {
     }
 
     #[test]
-    fn to_rank_weight() {
-
-    }
+    fn to_rank_weight() {}
 
     #[test]
     fn count() {

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -184,7 +184,12 @@ mod card_tests {
     }
 
     #[test]
-    fn to_rank_weight() {}
+    fn to_rank_weight() {
+        let card = Card::new(Rank::new(ACE), Suit::new(SPADES));
+        let rank_weighted_card = card.to_rank_weight();
+
+        assert_eq!(rank_weighted_card.weight, 12004);
+    }
 
     #[test]
     fn count() {

--- a/src/cards/pile.rs
+++ b/src/cards/pile.rs
@@ -355,6 +355,9 @@ impl Pile {
         suit.symbol().as_str().to_owned() + " " + &cards.rank_indexes_with_separator(" ")
     }
 
+    /// Returns a Vector of index strings, one for each `Suit` in the `Pile`, that starts with
+    /// the `Card's` `Suit` symbol followed by the `Rank` for each `Card` in the `Pile`.
+    /// This is useful for creating displays such as the ones in Bridge columns.
     #[must_use]
     pub fn short_suit_indexes(&self) -> Vec<String> {
         self.sort()
@@ -371,6 +374,8 @@ impl Pile {
         self.short_suit_indexes().join("\n")
     }
 
+    /// Returns a new, sorted `Pile`. Sorting is determined by the weight set for
+    /// each `Card` in the `Pile`.
     #[must_use]
     pub fn shuffle(&self) -> Pile {
         let mut shuffled = self.clone();
@@ -392,6 +397,29 @@ impl Pile {
     pub fn sort_in_place(&mut self) {
         self.0.sort();
         self.0.reverse();
+    }
+
+    /// Takes the entire Pile and returns a new Pile where the cards in it are Rank weighted first
+    /// instead of Suit weighted first. Useful for when displays need to sort by Rank.
+    ///
+    /// ```
+    /// use cardpack::{Card, CLUBS, HEARTS, JACK, QUEEN, Pile};
+    ///
+    /// let qh = Card::from_index_strings(QUEEN, HEARTS);
+    /// let jh = Card::from_index_strings(JACK, HEARTS);
+    /// let qc = Card::from_index_strings(QUEEN, CLUBS);
+    /// let jc = Card::from_index_strings(JACK, CLUBS);
+    ///
+    /// let pile = Pile::from_vector(vec![qh, jh, jc, qc]);
+    /// let rank_weighted = pile.convert_to_rank_sort();
+    ///
+    /// println!("{}", rank_weighted.sort());
+    /// ```
+    /// This will print out `QH QC JH JC`.
+    ///
+    #[must_use]
+    pub fn convert_to_rank_sort(&self) -> Pile {
+        self.0.iter().map(Card::to_rank_weight).collect()
     }
 
     /// Returns a sorted collection of the unique Suits in a Pile.
@@ -680,6 +708,23 @@ mod pile_tests {
         let v = pile.cards_by_suit(qc.suit);
 
         assert_eq!(expected, v);
+
+        format!("{}", pile.convert_to_rank_sort().sort());
+    }
+
+    #[test]
+    fn convert_to_rank_sort() {
+        let qh = Card::from_index_strings(QUEEN, HEARTS);
+        let jh = Card::from_index_strings(JACK, HEARTS);
+        let qc = Card::from_index_strings(QUEEN, CLUBS);
+        let jc = Card::from_index_strings(JACK, CLUBS);
+
+        let pile = Pile::from_vector(vec![qh, jh, jc, qc]);
+
+        assert_eq!(
+            "QH QC JH JC",
+            format!("{}", pile.convert_to_rank_sort().sort())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Added the ability for a Card to be weighted first by the Rank instead of by the Suit to facilitate alternative forms of sorting.